### PR TITLE
manifest: Remove AndroidAsync dependency

### DIFF
--- a/snippets/aicp.xml
+++ b/snippets/aicp.xml
@@ -27,7 +27,6 @@
   <project path="external/gello-build" name="CyanogenMod/android_external_gello_build" />
   <project path="external/google" name="CyanogenMod/android_external_google" />
   <project path="external/htop" name="CyanogenMod/android_external_htop" />
-  <project path="external/koush/AndroidAsync" name="CyanogenMod/AndroidAsync" />
   <project path="external/koush/ion" name="CyanogenMod/ion" />
   <project path="external/libncurses" name="CyanogenMod/android_external_libncurses" />
   <project path="external/libphonenumbergoogle" name="CyanogenMod/android_external_libphonenumbergoogle" />


### PR DESCRIPTION
 * We still need to compile Ion ourselves due to patches and bugfixes
   which haven't been upstreamed, but we now declare our dependencies
   using Maven so this can be dropped.

Change-Id: Ib452e5d16c406e7aaebeb2cbe3239809a33ac9c1